### PR TITLE
add task_lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For up-to-date information, it is probably best to take a quick look at [the sou
 | `grid_tables`                    | markdown-it-gridtables       |
 | `subscript`                      | markdown-it-sub              |
 | `superscript`                    | markdown-it-sup              |
+| `task_lists`                     | markdown-it-task-lists       |
 | `katex`                          | markdown-it-texmath, katex   |
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare const markdownItPandoc: (md: MarkdownIt, opts?: {
   katex:            boolean;
   subscript:        boolean;
   superscript:      boolean;
+  task_lists:       boolean;
 }) => MarkdownIt
 
 export default markdownItPandoc

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
                , katex:                      true
                , subscript:                  true
                , superscript:                true
+               , task_lists:                 true
                }
              , markdownItPandocOpts)
 
@@ -69,6 +70,10 @@ module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
 
   if (opts.superscript) {
     md = md.use( require('markdown-it-sup') );
+  }
+
+  if (opts.task_lists) {
+    md = md.use( require('markdown-it-task-lists') );
   }
 
   if (opts.katex) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-pandoc",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Package bundling a few markdown-it plugins to approximate pandoc flavoured markdown",
   "keywords": [
     "markdown-it-plugin",


### PR DESCRIPTION
This add supports of [`task_lists`](https://pandoc.org/MANUAL.html#extension-task_lists) via `markdown-it-task-lists`.