### PR TITLE
Add MathJax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For up-to-date information, it is probably best to take a quick look at [the sou
 | `superscript`                    | markdown-it-sup              |
 | `task_lists`                     | markdown-it-task-lists       |
 | `katex`                          | markdown-it-texmath, katex   |
-
+| `mathjax`                        | markdown-it-mathjax3         |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ const md = markdownItPandoc(
 );
 md.render('my markdown string');
 ```
+Note that MathJax and KaTeX are exclusive features.
+You cannot set both options true.

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare const markdownItPandoc: (md: MarkdownIt, opts?: {
   implicit_figures?: boolean;
   grid_tables?:      boolean;
   katex?:            boolean;
+  mathjax?:          boolean;
   subscript?:        boolean;
   superscript?:      boolean;
   task_lists?:       boolean;

--- a/index.js
+++ b/index.js
@@ -77,13 +77,13 @@ module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
     md = md.use( require('markdown-it-task-lists') );
   }
 
-  if (opts.katex) {
+  if (opts.katex && !opts.mathjax) {
     md = md.use(
       require('markdown-it-texmath').use( require('katex') )
     );
   }
 
-  if (opts.mathjax) {
+  if (opts.mathjax && !opts.katex) {
     md = md.use( require('markdown-it-mathjax3') );
   }
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
                , implicit_figures:           true
                , grid_tables:                true
                , katex:                      true
+               , mathjax:                    false
                , subscript:                  true
                , superscript:                true
                , task_lists:                 true
@@ -80,6 +81,10 @@ module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
     md = md.use(
       require('markdown-it-texmath').use( require('katex') )
     );
+  }
+
+  if (opts.mathjax) {
+    md = md.use( require('markdown-it-mathjax3') );
   }
 
   return md;


### PR DESCRIPTION
Thanks for developing a great project that allows Markdown to be similar to Pandoc. I made this pull request because I think it would be great if MathJax could render not only KaTeX, but also MathJax, so that it could represent more mathematical expressions and be closer to the actual Pandoc. In fact, Pandoc has an option to output HTML with MathJax as well as KaTeX. I hope this will lead to a higher level of compatibility.

Thank you for your cooperation.