### PR TITLE
feat: Add highlight JS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare const markdownItPandoc: (md: MarkdownIt, opts?: {
   subscript?:        boolean;
   superscript?:      boolean;
   task_lists?:       boolean;
+  highlight?:        boolean;
 }) => MarkdownIt
 
 export default markdownItPandoc

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
   }
 
   if (opts.highlight) {
-    md = md.use(require("markdown-it-highlightjs"));
+    md = md.use(require("markdown-it-highlightjs"), {auto: true});
   }
 
   return md;

--- a/index.js
+++ b/index.js
@@ -2,90 +2,94 @@
 
 module.exports = function markdownItPandoc(md, markdownItPandocOpts) {
   var opts = Object.assign(
-               {
-                 attributes:                 true
-               , bracketed_spans:            true
-               , definition_lists:           true
-               , fenced_divs:                true
-               , footnotes:                  true
-               , implicit_figures:           true
-               , grid_tables:                true
-               , katex:                      true
-               , mathjax:                    false
-               , subscript:                  true
-               , superscript:                true
-               , task_lists:                 true
-               }
-             , markdownItPandocOpts)
+    {
+      attributes: true,
+      bracketed_spans: true,
+      definition_lists: true,
+      fenced_divs: true,
+      footnotes: true,
+      implicit_figures: true,
+      grid_tables: true,
+      katex: true,
+      mathjax: false,
+      subscript: true,
+      superscript: true,
+      task_lists: true,
+      highlight: true,
+    },
+    markdownItPandocOpts
+  );
 
   if (opts.bracketed_spans && opts.attributes) {
-    md = md.use( require('markdown-it-bracketed-spans') );
+    md = md.use(require("markdown-it-bracketed-spans"));
   }
 
   if (opts.attributes) {
     // TODO: sanitize attrs (at least keys with `on*` and vals with `javascript:*`, see https://github.com/arve0/markdown-it-attrs#security
-    md = md.use( require('markdown-it-attrs') )
+    md = md.use(require("markdown-it-attrs"));
   }
 
   if (opts.fenced_divs && opts.attributes) {
-    md = md.use( require('markdown-it-container'), 'dynamic', {
-              // adapted from https://github.com/markdown-it/markdown-it-container/issues/23
-              validate: function() { return true; },
-              render: function(tokens, idx, options, env, slf) {
-                var token     = tokens[idx]
-                  , className = token.info.trim()
-                  , renderedAttrs = slf.renderAttrs(token)
-                  ;
-                if (token.nesting === 1) {
-                  return (className && className !== '{}')
-                          ? '<div class="' + className + '">'
-                          : '<div' + renderedAttrs + '>'
-                          ;
-                } else {
-                  return '</div>';
-                }
-              }
-            });
+    md = md.use(require("markdown-it-container"), "dynamic", {
+      // adapted from https://github.com/markdown-it/markdown-it-container/issues/23
+      validate: function () {
+        return true;
+      },
+      render: function (tokens, idx, options, env, slf) {
+        var token = tokens[idx],
+          className = token.info.trim(),
+          renderedAttrs = slf.renderAttrs(token);
+        if (token.nesting === 1) {
+          return className && className !== "{}"
+            ? '<div class="' + className + '">'
+            : "<div" + renderedAttrs + ">";
+        } else {
+          return "</div>";
+        }
+      },
+    });
   }
 
   if (opts.definition_lists) {
-    md = md.use( require('markdown-it-deflist') );
+    md = md.use(require("markdown-it-deflist"));
   }
 
   if (opts.footnotes) {
-    md = md.use( require('markdown-it-footnote') );
+    md = md.use(require("markdown-it-footnote"));
   }
 
   if (opts.implicit_figures) {
-    md = md.use( require('markdown-it-implicit-figures'), {figcaption: true} );
+    md = md.use(require("markdown-it-implicit-figures"), { figcaption: true });
   }
 
   if (opts.grid_tables) {
-    var gridtables = require('markdown-it-gridtables').default
+    var gridtables = require("markdown-it-gridtables").default;
     md = md.use(gridtables);
   }
 
   if (opts.subscript) {
-    md = md.use( require('markdown-it-sub') );
+    md = md.use(require("markdown-it-sub"));
   }
 
   if (opts.superscript) {
-    md = md.use( require('markdown-it-sup') );
+    md = md.use(require("markdown-it-sup"));
   }
 
   if (opts.task_lists) {
-    md = md.use( require('markdown-it-task-lists') );
+    md = md.use(require("markdown-it-task-lists"));
   }
 
   if (opts.katex && !opts.mathjax) {
-    md = md.use(
-      require('markdown-it-texmath').use( require('katex') )
-    );
+    md = md.use(require("markdown-it-texmath").use(require("katex")));
   }
 
   if (opts.mathjax && !opts.katex) {
-    md = md.use( require('markdown-it-mathjax3') );
+    md = md.use(require("markdown-it-mathjax3"));
+  }
+
+  if (opts.highlight) {
+    md = md.use(require("markdown-it-highlightjs"));
   }
 
   return md;
-}
+};

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
   "homepage": "https://github.com/mb21/markdown-it-pandoc",
   "devDependencies": {
     "@types/markdown-it": "^12.0.3"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
This add supports of code block highlighting via `markdown-it-highlightjs`. 
It should also close _post by @mb21 in https://github.com/mb21/panwriter/issues/96#issuecomment-1024105376_
