### PR TITLE
proper export of MarkdownItPandocOptions so it can actually be used by panwriter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it'
 
-export interface MarkdownItPandocOptions {
+interface MarkdownItPandocOptions {
   attributes?:       boolean;
   bracketed_spans?:  boolean;
   definition_lists?: boolean;
@@ -21,4 +21,10 @@ export interface MarkdownItPandocOptions {
 
 declare const markdownItPandoc: (md: MarkdownIt, opts?: MarkdownItPandocOptions) => MarkdownIt
 
-export default markdownItPandoc
+// Export both the function and the options interface
+declare namespace markdownItPandoc {
+  export { MarkdownItPandocOptions };
+}
+
+// Export using CommonJS style
+export = markdownItPandoc;


### PR DESCRIPTION
UGH... HOLD OFF on this. I'm learning as I go (about "CommonJS" vs "ES module imports"). Sorry. There's got to be a ES module import variation that will work. I'll figure it out.

Oops. Turns out things needed to be exported differently to properly allow MarkdownItPandocOptions to be used in panwriter. (I didn't test before. My bad. So sorry.)

This has been tested with panwriter.

Prior to this there was an issue caused where panwriter couldn't see the options type _and_ it was having some odd conflict with the way MarkdownIt was imported in index.d.ts.

